### PR TITLE
Add PublicHolidays Controller and Tests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/PublicHolidaysController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/PublicHolidaysController.java
@@ -1,9 +1,41 @@
 package edu.ucsb.cs156.spring.backenddemo.controllers;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
+import edu.ucsb.cs156.spring.backenddemo.services.PublicHolidayQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+@Tag(name="Public Holiday Info from https://date.nager.at/Api")
+@Slf4j
 @RestController
+@RequestMapping("/api/PublicHolidays")
 public class PublicHolidaysController {
     
+    ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    PublicHolidayQueryService PublicHolidayQueryService;
+
+    @Operation(summary = "Get public holidays for a given year and country")
+    @GetMapping("/get")
+    public ResponseEntity<String> getPublicHolidays(
+        @Parameter(name="year", description="year", example="2012") @RequestParam String year,
+        @Parameter(name="countryCode", description="2 letter country code", example="US, MX, CN") @RequestParam String countryCode
+    ) throws JsonProcessingException {
+        log.info("getPublicHolidays: year={} countryCode={}", year, countryCode);
+        String result = PublicHolidayQueryService.getJSON(year, countryCode);
+        return ResponseEntity.ok().body(result);
+    }
+
 }

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/PublicHolidayQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/PublicHolidayQueryService.java
@@ -13,14 +13,14 @@ import org.springframework.web.client.HttpClientErrorException;
 @Service
 public class PublicHolidayQueryService {
 
-
+    
     private final RestTemplate restTemplate;
 
     public PublicHolidayQueryService(RestTemplateBuilder restTemplateBuilder) {
         restTemplate = restTemplateBuilder.build();
     }
 
-    public static final String ENDPOINT = "";
+    public static final String ENDPOINT = "https://date.nager.at/api/v2/publicholidays/{year}/{countryCode}";
 
     public String getJSON(String year, String countryCode) throws HttpClientErrorException {
         return "";

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/PublicHolidayQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/PublicHolidayQueryService.java
@@ -4,8 +4,15 @@ import org.springframework.web.client.RestTemplate;
 
 import lombok.extern.slf4j.Slf4j;
 
-import org.springframework.boot.web.client.RestTemplateBuilder;
+import java.util.List;
+import java.util.Map;
 
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 
@@ -13,7 +20,7 @@ import org.springframework.web.client.HttpClientErrorException;
 @Service
 public class PublicHolidayQueryService {
 
-    
+
     private final RestTemplate restTemplate;
 
     public PublicHolidayQueryService(RestTemplateBuilder restTemplateBuilder) {
@@ -23,7 +30,17 @@ public class PublicHolidayQueryService {
     public static final String ENDPOINT = "https://date.nager.at/api/v2/publicholidays/{year}/{countryCode}";
 
     public String getJSON(String year, String countryCode) throws HttpClientErrorException {
-        return "";
+        log.info("year={}, countryCode={}", year, countryCode);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        Map<String, String> uriVariables = Map.of("year", year, "countryCode", countryCode);
+        
+        ResponseEntity<String> re = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class, uriVariables);
+        return re.getBody();
     }
 
    

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/PublicHolidayQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/PublicHolidayQueryService.java
@@ -1,11 +1,13 @@
 package edu.ucsb.cs156.spring.backenddemo.services;
 
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.springframework.web.client.RestTemplate;
 
 import lombok.extern.slf4j.Slf4j;
-
-import java.util.List;
-import java.util.Map;
 
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpEntity;
@@ -20,6 +22,7 @@ import org.springframework.web.client.HttpClientErrorException;
 @Service
 public class PublicHolidayQueryService {
 
+    ObjectMapper mapper = new ObjectMapper();
 
     private final RestTemplate restTemplate;
 

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/PublicHolidaysControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/PublicHolidaysControllerTests.java
@@ -1,0 +1,60 @@
+package edu.ucsb.cs156.spring.backenddemo.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import edu.ucsb.cs156.spring.backenddemo.services.PublicHolidayQueryService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpHeaders;
+
+
+@WebMvcTest(value = PublicHolidaysController.class)
+public class PublicHolidaysControllerTests {
+  private ObjectMapper mapper = new ObjectMapper();
+  @Autowired
+  private MockMvc mockMvc;
+  @MockBean
+  PublicHolidayQueryService mockPublicHoldiaysQueryService;
+
+
+  @Test
+  public void test_getPublicHolidays() throws Exception {
+  
+    String fakeJsonResult="{ \"fake\" : \"result\" }";
+    String year = "2023";
+    String countryCode = "US";
+    when(mockPublicHoldiaysQueryService.getJSON(eq(year),eq(countryCode))).thenReturn(fakeJsonResult);
+
+    String url = String.format("/api/PublicHolidays/get?year=%s&countryCode=%s",year,countryCode);
+
+    MvcResult response = mockMvc
+        .perform( get(url).contentType("application/json"))
+        .andExpect(status().isOk()).andReturn();
+
+    String responseString = response.getResponse().getContentAsString();
+
+    assertEquals(fakeJsonResult, responseString);
+  }
+
+}

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/PublicHolidayQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/PublicHolidayQueryServiceTests.java
@@ -1,0 +1,45 @@
+package edu.ucsb.cs156.spring.backenddemo.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+
+@RestClientTest(PublicHolidayQueryService.class)
+public class PublicHolidayQueryServiceTests {
+    @Autowired
+    private MockRestServiceServer mockRestServiceServer;
+
+    @Autowired
+    private PublicHolidayQueryService PublicHolidayQueryService;
+
+    /**
+     * 
+     */
+    @Test
+    public void test_getJSON() {
+
+        String year = "2020";
+        String countryCode = "US";
+        String expectedURL = PublicHolidayQueryService.ENDPOINT.replace("{year}", year)
+                .replace("{countryCode}", countryCode);
+
+        String fakeJsonResult = "{ \"fake\" : \"result\" }";
+
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andRespond(withSuccess(fakeJsonResult, MediaType.APPLICATION_JSON));
+
+        String actualResult = PublicHolidayQueryService.getJSON(year, countryCode);
+        assertEquals(fakeJsonResult, actualResult);
+    }
+
+}


### PR DESCRIPTION
In this PR, we add an endpoint `/api/PublicHolidays/get` that can be used to get information about public holidays in countries

dev deployment:
http://team01-mohamed-elfouly.dokku-02.cs.ucsb.edu/swagger-ui/index.html  

Closes #8 